### PR TITLE
Add profile route definitions

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\MovementController;
 use App\Http\Controllers\ProductController;
+use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ReportController;
 use App\Http\Controllers\SupplierController;
 use Illuminate\Support\Facades\Route;
@@ -22,6 +23,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::get('/reports/summary', [ReportController::class, 'summary'])->name('reports.summary');
     Route::get('/reports/kardex', [ReportController::class, 'kardex'])->name('reports.kardex');
+
+    Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
+    Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
+    Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- register the profile routes within the authenticated middleware group so the navigation link resolves
- import the ProfileController required by the new routes

## Testing
- php artisan test *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6078831988325bad192bcc6beb5fc