### PR TITLE
Add warehouse management and stock location support

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -54,16 +54,25 @@ class ProductController extends Controller
         $product = Product::create($data);
 
         if (
-            ! empty($data['warehouse_id']) &&
-            array_key_exists('initial_stock', $data) &&
-            $data['initial_stock'] !== null
+            ! empty($data['warehouse_id'] ?? null) &&
+            (
+                array_key_exists('initial_stock', $data)
+                || array_key_exists('stock_location', $data)
+            )
         ) {
+            $initialStock = array_key_exists('initial_stock', $data) && $data['initial_stock'] !== null
+                ? (int) $data['initial_stock']
+                : 0;
+
             ProductStock::updateOrCreate(
                 [
                     'product_id' => $product->id,
                     'warehouse_id' => $data['warehouse_id'],
                 ],
-                ['current_stock' => (int) $data['initial_stock']]
+                [
+                    'current_stock' => $initialStock,
+                    'location' => $data['stock_location'] ?? null,
+                ]
             );
         }
 

--- a/app/Http/Controllers/WarehouseController.php
+++ b/app/Http/Controllers/WarehouseController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Warehouse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Illuminate\View\View;
+
+class WarehouseController extends Controller
+{
+    public function index(): View
+    {
+        $warehouses = Warehouse::withCount('stocks')
+            ->withSum('stocks as total_stock', 'current_stock')
+            ->orderBy('name')
+            ->paginate(15)
+            ->withQueryString();
+
+        return view('warehouses.index', compact('warehouses'));
+    }
+
+    public function create(): View
+    {
+        return view('warehouses.create');
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:150'],
+            'code' => ['required', 'string', 'max:50', 'unique:warehouses,code'],
+            'location' => ['nullable', 'string', 'max:150'],
+        ]);
+
+        Warehouse::create($data);
+
+        return redirect()->route('warehouses.index')->with('ok', 'Almacén creado correctamente.');
+    }
+
+    public function edit(Warehouse $warehouse): View
+    {
+        return view('warehouses.edit', compact('warehouse'));
+    }
+
+    public function update(Request $request, Warehouse $warehouse): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:150'],
+            'code' => [
+                'required',
+                'string',
+                'max:50',
+                Rule::unique('warehouses', 'code')->ignore($warehouse->id),
+            ],
+            'location' => ['nullable', 'string', 'max:150'],
+        ]);
+
+        $warehouse->update($data);
+
+        return redirect()->route('warehouses.index')->with('ok', 'Almacén actualizado correctamente.');
+    }
+
+    public function destroy(Warehouse $warehouse): RedirectResponse
+    {
+        if ($warehouse->stocks()->exists()) {
+            return redirect()
+                ->route('warehouses.index')
+                ->with('error', 'No puedes eliminar un almacén con stock asociado.');
+        }
+
+        $warehouse->delete();
+
+        return redirect()->route('warehouses.index')->with('ok', 'Almacén eliminado correctamente.');
+    }
+}

--- a/app/Http/Requests/StoreProductRequest.php
+++ b/app/Http/Requests/StoreProductRequest.php
@@ -27,6 +27,7 @@ class StoreProductRequest extends FormRequest
             'supplier_id' => ['nullable', 'exists:suppliers,id'],
             'warehouse_id' => ['nullable', 'exists:warehouses,id'],
             'initial_stock' => ['nullable', 'integer', 'min:0'],
+            'stock_location' => ['nullable', 'string', 'max:120'],
         ];
     }
 }

--- a/app/Models/ProductStock.php
+++ b/app/Models/ProductStock.php
@@ -10,7 +10,7 @@ class ProductStock extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['product_id', 'warehouse_id', 'current_stock'];
+    protected $fillable = ['product_id', 'warehouse_id', 'current_stock', 'location'];
 
     public function product(): BelongsTo
     {

--- a/database/migrations/2025_09_30_000000_add_location_to_product_stocks_table.php
+++ b/database/migrations/2025_09_30_000000_add_location_to_product_stocks_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('product_stocks', function (Blueprint $table) {
+            if (! Schema::hasColumn('product_stocks', 'location')) {
+                $table->string('location', 120)->nullable()->after('current_stock');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('product_stocks', function (Blueprint $table) {
+            if (Schema::hasColumn('product_stocks', 'location')) {
+                $table->dropColumn('location');
+            }
+        });
+    }
+};

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -73,6 +73,11 @@
                         Proveedores
                     </x-nav-link>
 
+                    {{-- Almacenes --}}
+                    <x-nav-link :href="route('warehouses.index')" :active="request()->routeIs('warehouses.*')">
+                        Almacenes
+                    </x-nav-link>
+
                     {{-- Reportes (dropdown simple) --}}
                     <div x-data="{ openRep:false }" class="relative">
                         <button type="button"
@@ -178,6 +183,10 @@
 
             <x-responsive-nav-link :href="route('suppliers.index')" :active="request()->routeIs('suppliers.*')">
                 Proveedores
+            </x-responsive-nav-link>
+
+            <x-responsive-nav-link :href="route('warehouses.index')" :active="request()->routeIs('warehouses.*')">
+                Almacenes
             </x-responsive-nav-link>
 
             <details class="group">

--- a/resources/views/products/create.blade.php
+++ b/resources/views/products/create.blade.php
@@ -79,6 +79,7 @@
                         <option value="{{ $category->id }}" @selected(old('category_id') == $category->id)>{{ $category->name }}</option>
                     @endforeach
                 </select>
+                <p class="mt-1 text-xs"><a href="{{ route('categories.create') }}" class="text-orange-600 hover:underline">Crear nueva categoría</a></p>
                 @error('category_id') <p class="text-sm text-red-600 mt-1">{{ $message }}</p> @enderror
             </div>
 
@@ -91,6 +92,7 @@
                         <option value="{{ $supplier->id }}" @selected(old('supplier_id') == $supplier->id)>{{ $supplier->name }}</option>
                     @endforeach
                 </select>
+                <p class="mt-1 text-xs"><a href="{{ route('suppliers.create') }}" class="text-orange-600 hover:underline">Registrar proveedor</a></p>
                 @error('supplier_id') <p class="text-sm text-red-600 mt-1">{{ $message }}</p> @enderror
             </div>
 
@@ -117,6 +119,7 @@
                         <option value="{{ $warehouse->id }}" @selected(old('warehouse_id') == $warehouse->id)>{{ $warehouse->code }} - {{ $warehouse->name }}</option>
                     @endforeach
                 </select>
+                <p class="mt-1 text-xs"><a href="{{ route('warehouses.create') }}" class="text-orange-600 hover:underline">Crear almacén</a></p>
                 @error('warehouse_id') <p class="text-sm text-red-600 mt-1">{{ $message }}</p> @enderror
             </div>
 
@@ -125,6 +128,15 @@
                 <input id="initial_stock" name="initial_stock" type="number" min="0" value="{{ old('initial_stock') }}"
                        class="mt-1 block w-full rounded-md text-gray-900 border-gray-300 shadow-sm focus:border-orange-500 focus:ring-orange-500">
                 @error('initial_stock') <p class="text-sm text-red-600 mt-1">{{ $message }}</p> @enderror
+            </div>
+
+            <div>
+                <label for="stock_location" class="block text-sm font-medium text-gray-700">Ubicación en almacén</label>
+                <input id="stock_location" name="stock_location" type="text" value="{{ old('stock_location') }}"
+                       placeholder="Ej. Estante A3"
+                       class="mt-1 block w-full rounded-md text-gray-900 border-gray-300 shadow-sm focus:border-orange-500 focus:ring-orange-500">
+                <p class="mt-1 text-xs text-gray-500">Opcional. Describe dónde se guarda el producto.</p>
+                @error('stock_location') <p class="text-sm text-red-600 mt-1">{{ $message }}</p> @enderror
             </div>
         </div>
 

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -69,6 +69,7 @@
                         <option value="{{ $category->id }}" @selected(old('category_id', $product->category_id) == $category->id)>{{ $category->name }}</option>
                     @endforeach
                 </select>
+                <p class="mt-1 text-xs"><a href="{{ route('categories.create') }}" class="text-orange-600 hover:underline">Crear nueva categoría</a></p>
                 @error('category_id') <p class="text-sm text-red-600 mt-1">{{ $message }}</p> @enderror
             </div>
 
@@ -81,6 +82,7 @@
                         <option value="{{ $supplier->id }}" @selected(old('supplier_id', $product->supplier_id) == $supplier->id)>{{ $supplier->name }}</option>
                     @endforeach
                 </select>
+                <p class="mt-1 text-xs"><a href="{{ route('suppliers.create') }}" class="text-orange-600 hover:underline">Registrar proveedor</a></p>
                 @error('supplier_id') <p class="text-sm text-red-600 mt-1">{{ $message }}</p> @enderror
             </div>
 

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -32,17 +32,21 @@
       </thead>
       <tbody>
         @forelse($products as $product)
-          <tr class="border-t">
+          <tr class="border-t text-gray-700">
             <td class="px-3 py-2">{{ $product->internal_code }}</td>
             <td class="px-3 py-2">{{ $product->part_number }}</td>
             <td class="px-3 py-2">{{ $product->item }}</td>
-            <td class="px-3 py-2">{{ $product->name_item }}</td>
+            <td class="px-3 py-2 font-medium text-gray-800">{{ $product->name_item }}</td>
             <td class="px-3 py-2">{{ $product->unit }}</td>
-            <td class="px-3 py-2 text-center font-semibold">{{ $product->total_stock }}</td>
+            <td class="px-3 py-2 text-center font-semibold text-gray-900">{{ $product->total_stock }}</td>
             <td class="px-3 py-2">
               @forelse($product->stocks as $stock)
-                <span class="inline-block rounded bg-slate-100 px-2 py-0.5 mr-1">
-                  {{ $stock->warehouse->code ?? $stock->warehouse->name }}: {{ $stock->current_stock }}
+                <span class="inline-flex items-center gap-1 rounded border border-slate-200 bg-slate-50 px-2 py-0.5 mr-1 text-slate-700">
+                  <span class="font-medium text-slate-900">{{ $stock->warehouse->code ?? $stock->warehouse->name }}</span>
+                  <span>- {{ $stock->current_stock }}</span>
+                  @if($stock->location)
+                    <span class="text-xs text-slate-500">({{ $stock->location }})</span>
+                  @endif
                 </span>
               @empty
                 <span class="text-gray-400">Sin stock</span>

--- a/resources/views/products/show.blade.php
+++ b/resources/views/products/show.blade.php
@@ -44,9 +44,17 @@
     <h2 class="text-xl font-semibold text-gray-800 mt-6 mb-3">Stock por almacén</h2>
     <ul class="space-y-2">
       @forelse($product->stocks as $stock)
-        <li class="flex justify-between rounded bg-slate-50 px-3 py-2">
-          <span>{{ $stock->warehouse->name ?? 'Almacén' }}</span>
-          <span class="font-semibold">{{ $stock->current_stock }}</span>
+        <li class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 rounded border border-slate-200 bg-slate-50 px-3 py-2 text-gray-700">
+          <div>
+            <span class="font-semibold text-gray-900">{{ $stock->warehouse->code ?? $stock->warehouse->name }}</span>
+            <span class="text-sm text-gray-500">{{ $stock->warehouse->name ?? '' }}</span>
+          </div>
+          <div class="flex items-center gap-2">
+            <span class="font-semibold text-gray-900">{{ $stock->current_stock }}</span>
+            @if($stock->location)
+              <span class="text-xs text-gray-500">Ubicación: {{ $stock->location }}</span>
+            @endif
+          </div>
         </li>
       @empty
         <li class="text-gray-500">Sin stock registrado.</li>

--- a/resources/views/warehouses/_form.blade.php
+++ b/resources/views/warehouses/_form.blade.php
@@ -1,0 +1,27 @@
+@php($warehouse ??= null)
+@csrf
+<div class="grid gap-4">
+  <div>
+    <label for="name" class="block text-sm font-medium text-gray-700">Nombre *</label>
+    <input id="name" name="name" type="text" value="{{ old('name', $warehouse->name ?? '') }}" required
+           class="mt-1 block w-full rounded-md border-gray-300 text-gray-900 shadow-sm focus:border-orange-500 focus:ring-orange-500">
+    @error('name') <p class="text-sm text-red-600 mt-1">{{ $message }}</p> @enderror
+  </div>
+  <div>
+    <label for="code" class="block text-sm font-medium text-gray-700">Código *</label>
+    <input id="code" name="code" type="text" value="{{ old('code', $warehouse->code ?? '') }}" required
+           class="mt-1 block w-full rounded-md border-gray-300 text-gray-900 shadow-sm focus:border-orange-500 focus:ring-orange-500">
+    @error('code') <p class="text-sm text-red-600 mt-1">{{ $message }}</p> @enderror
+  </div>
+  <div>
+    <label for="location" class="block text-sm font-medium text-gray-700">Ubicación</label>
+    <input id="location" name="location" type="text" value="{{ old('location', $warehouse->location ?? '') }}"
+           placeholder="Ej. Calle 123 - Depósito"
+           class="mt-1 block w-full rounded-md border-gray-300 text-gray-900 shadow-sm focus:border-orange-500 focus:ring-orange-500">
+    @error('location') <p class="text-sm text-red-600 mt-1">{{ $message }}</p> @enderror
+  </div>
+</div>
+<div class="mt-6 flex justify-end">
+  <a href="{{ route('warehouses.index') }}" class="mr-3 px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300">Cancelar</a>
+  <button type="submit" class="px-4 py-2 bg-orange-600 text-white rounded-md hover:bg-orange-700">Guardar</button>
+</div>

--- a/resources/views/warehouses/create.blade.php
+++ b/resources/views/warehouses/create.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.app')
+
+@section('title', 'Nuevo almacén')
+
+@section('content')
+  <div class="max-w-xl mx-auto bg-white shadow rounded-lg p-6">
+    <h1 class="text-2xl font-semibold text-gray-800 mb-4">Nuevo almacén</h1>
+    <form method="post" action="{{ route('warehouses.store') }}">
+      @include('warehouses._form')
+    </form>
+  </div>
+@endsection

--- a/resources/views/warehouses/edit.blade.php
+++ b/resources/views/warehouses/edit.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+
+@section('title', 'Editar almacén')
+
+@section('content')
+  <div class="max-w-xl mx-auto bg-white shadow rounded-lg p-6">
+    <h1 class="text-2xl font-semibold text-gray-800 mb-4">Editar almacén</h1>
+    <form method="post" action="{{ route('warehouses.update', $warehouse) }}">
+      @method('put')
+      @include('warehouses._form', ['warehouse' => $warehouse])
+    </form>
+  </div>
+@endsection

--- a/resources/views/warehouses/index.blade.php
+++ b/resources/views/warehouses/index.blade.php
@@ -1,0 +1,52 @@
+@extends('layouts.app')
+
+@section('title', 'Almacenes')
+
+@section('content')
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-semibold text-gray-800">Almacenes</h1>
+    <a href="{{ route('warehouses.create') }}" class="px-4 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700">Nuevo almacén</a>
+  </div>
+
+  <div class="overflow-x-auto bg-white shadow rounded-lg">
+    <table class="min-w-full text-sm">
+      <thead class="bg-slate-50 text-left">
+        <tr>
+          <th class="px-3 py-2">Nombre</th>
+          <th class="px-3 py-2">Código</th>
+          <th class="px-3 py-2">Ubicación</th>
+          <th class="px-3 py-2 text-center">Stock total</th>
+          <th class="px-3 py-2 text-center">Productos distintos</th>
+          <th class="px-3 py-2 text-right">Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        @forelse($warehouses as $warehouse)
+          <tr class="border-t text-gray-700">
+            <td class="px-3 py-2 font-medium text-gray-800">{{ $warehouse->name }}</td>
+            <td class="px-3 py-2">{{ $warehouse->code }}</td>
+            <td class="px-3 py-2">{{ $warehouse->location ?? '—' }}</td>
+            <td class="px-3 py-2 text-center font-semibold text-gray-900">{{ $warehouse->total_stock ?? 0 }}</td>
+            <td class="px-3 py-2 text-center">{{ $warehouse->stocks_count }}</td>
+            <td class="px-3 py-2 text-right space-x-2">
+              <a href="{{ route('warehouses.edit', $warehouse) }}" class="text-blue-600 hover:underline">Editar</a>
+              <form action="{{ route('warehouses.destroy', $warehouse) }}" method="post" class="inline">
+                @csrf
+                @method('delete')
+                <button type="submit" class="text-red-600 hover:underline" onclick="return confirm('¿Eliminar este almacén?')">Eliminar</button>
+              </form>
+            </td>
+          </tr>
+        @empty
+          <tr>
+            <td colspan="6" class="px-3 py-4 text-center text-gray-500">Aún no hay almacenes registrados.</td>
+          </tr>
+        @endforelse
+      </tbody>
+    </table>
+  </div>
+
+  <div class="mt-4">
+    {{ $warehouses->links() }}
+  </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\ProductController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ReportController;
 use App\Http\Controllers\SupplierController;
+use App\Http\Controllers\WarehouseController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', fn () => redirect()->route('dashboard'))->name('home');
@@ -17,6 +18,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::resource('products', ProductController::class);
     Route::resource('categories', CategoryController::class)->except(['show']);
     Route::resource('suppliers', SupplierController::class)->except(['show']);
+    Route::resource('warehouses', WarehouseController::class)->except(['show']);
 
     Route::get('/movements', [MovementController::class, 'index'])->name('movements.index');
     Route::post('/movements', [MovementController::class, 'store'])->name('movements.store');


### PR DESCRIPTION
## Summary
- add a stock location field when creating products and persist it on product stock records
- improve the product listing/show views to surface warehouse stock locations with better contrast
- introduce warehouse management screens and navigation so warehouses can be created, edited, or removed

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d628aaec3483259133e3b60b5859d9