### PR TITLE
Fix default text color contrast against backgrounds

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-gray-50 text-slate-800;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    body {
+      @apply bg-slate-900 text-slate-100;
+    }
+  }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -6,7 +6,7 @@
   @vite(['resources/css/app.css','resources/js/app.js'])
   <title>@yield('title','Inventario')</title>
 </head>
-<body class="min-h-full bg-white text-slate-800 dark:bg-gray-100 dark:text-slate-100">
+<body class="min-h-full bg-gray-50 text-slate-800 dark:bg-slate-900 dark:text-slate-100">
   @include('layouts.navigation')
 
   <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">


### PR DESCRIPTION
## Summary
- set base body colors to non-white defaults for both light and dark modes
- update the application layout to use the new neutral background and high-contrast text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d630bb16d08325845d0d7089ec2a89